### PR TITLE
feat(dts): forward JSDoc documentation into .d.ts files

### DIFF
--- a/.changes/unreleased/Added-20260318-152002.yaml
+++ b/.changes/unreleased/Added-20260318-152002.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |-
+    Forward JSDoc documentation into generated .d.ts files
+    Gleam /// doc comments are now emitted as JSDoc above type and function
+    declarations. Single-line docs use compact format; multi-line docs use
+    block format. Constructor-level docs are included for ADT variants.
+time: 2026-03-18T15:20:02.373997581-07:00

--- a/src/talc/dts.gleam
+++ b/src/talc/dts.gleam
@@ -174,7 +174,8 @@ fn emit_type_definition(
           let all_fields = [tag_field, ..fields]
 
           let iface =
-            "export interface "
+            doc_comment(constructor.documentation)
+            <> "export interface "
             <> constructor.name
             <> generics
             <> " {\n"
@@ -187,9 +188,10 @@ fn emit_type_definition(
       let constructor_names =
         list.map(constructors, fn(c) { c.name <> generics })
       let union_decl =
-        doc_comment(type_def.documentation)
-        <> string.join(interfaces, "\n\n")
-        <> "\n\nexport type "
+        string.join(interfaces, "\n\n")
+        <> "\n\n"
+        <> doc_comment(type_def.documentation)
+        <> "export type "
         <> name
         <> generics
         <> " = "
@@ -274,17 +276,34 @@ fn type_params_string(count: Int, ctx: TypeContext) -> String {
 }
 
 /// Formats an optional documentation string as a JSDoc comment.
+/// Single-line docs use compact `/** text */` format.
+/// Multi-line docs use block format.
 fn doc_comment(doc: option.Option(String)) -> String {
   case doc {
     None -> ""
     Some(text) -> {
-      let lines = string.split(text, "\n")
-      case lines {
-        [] -> ""
-        _ ->
-          "/**\n"
-          <> string.join(list.map(lines, fn(line) { " *" <> line }), "\n")
-          <> "\n */\n"
+      let trimmed = string.trim_end(text)
+      case trimmed {
+        "" -> ""
+        _ -> {
+          let lines = string.split(trimmed, "\n")
+          case lines {
+            [] -> ""
+            [single] -> "/** " <> string.trim(single) <> " */\n"
+            _ ->
+              "/**\n"
+              <> string.join(
+                list.map(lines, fn(line) {
+                  case string.is_empty(string.trim(line)) {
+                    True -> " *"
+                    False -> " * " <> line
+                  }
+                }),
+                "\n",
+              )
+              <> "\n */\n"
+          }
+        }
       }
     }
   }

--- a/test/dts_test.gleam
+++ b/test/dts_test.gleam
@@ -358,3 +358,214 @@ pub fn emit_cross_module_imports_test() {
   |> string.contains("import type { Handler } from \"./util.js\";")
   |> expect.to_be_true()
 }
+
+pub fn emit_function_with_single_line_doc_test() {
+  let module =
+    Module(
+      ..empty_module(),
+      functions: dict.from_list([
+        #(
+          "add",
+          Function(
+            documentation: Some("Adds two integers together."),
+            deprecation: None,
+            implementations: test_implementations(),
+            parameters: [
+              Parameter(
+                label: Some("a"),
+                type_: package_interface.Named("Int", "", "gleam", []),
+              ),
+              Parameter(
+                label: Some("b"),
+                type_: package_interface.Named("Int", "", "gleam", []),
+              ),
+            ],
+            return: package_interface.Named("Int", "", "gleam", []),
+          ),
+        ),
+      ]),
+    )
+
+  let result = dts.emit_module(module, "test", "test_module")
+  result.content
+  |> string.contains("/** Adds two integers together. */\n")
+  |> expect.to_be_true()
+  result.content
+  |> string.contains(
+    "export declare function add(a: number, b: number): number;",
+  )
+  |> expect.to_be_true()
+}
+
+pub fn emit_function_with_multi_line_doc_test() {
+  let module =
+    Module(
+      ..empty_module(),
+      functions: dict.from_list([
+        #(
+          "greet",
+          Function(
+            documentation: Some("Greets a person.\nReturns a friendly message."),
+            deprecation: None,
+            implementations: test_implementations(),
+            parameters: [
+              Parameter(
+                label: Some("name"),
+                type_: package_interface.Named("String", "", "gleam", []),
+              ),
+            ],
+            return: package_interface.Named("String", "", "gleam", []),
+          ),
+        ),
+      ]),
+    )
+
+  let result = dts.emit_module(module, "test", "test_module")
+  result.content
+  |> string.contains(
+    "/**\n * Greets a person.\n * Returns a friendly message.\n */\n",
+  )
+  |> expect.to_be_true()
+}
+
+pub fn emit_record_type_with_doc_test() {
+  let module =
+    Module(
+      ..empty_module(),
+      types: dict.from_list([
+        #(
+          "Person",
+          TypeDefinition(
+            documentation: Some("Represents a person with a name and age."),
+            deprecation: None,
+            parameters: 0,
+            constructors: [
+              TypeConstructor(documentation: None, name: "Person", parameters: [
+                Parameter(
+                  label: Some("name"),
+                  type_: package_interface.Named("String", "", "gleam", []),
+                ),
+                Parameter(
+                  label: Some("age"),
+                  type_: package_interface.Named("Int", "", "gleam", []),
+                ),
+              ]),
+            ],
+          ),
+        ),
+      ]),
+    )
+
+  let result = dts.emit_module(module, "test", "test_module")
+  result.content
+  |> string.contains(
+    "/** Represents a person with a name and age. */\nexport interface Person",
+  )
+  |> expect.to_be_true()
+}
+
+pub fn emit_adt_type_with_docs_test() {
+  let module =
+    Module(
+      ..empty_module(),
+      types: dict.from_list([
+        #(
+          "Shape",
+          TypeDefinition(
+            documentation: Some("A geometric shape."),
+            deprecation: None,
+            parameters: 0,
+            constructors: [
+              TypeConstructor(
+                documentation: Some("A circle with a radius."),
+                name: "Circle",
+                parameters: [
+                  Parameter(
+                    label: Some("radius"),
+                    type_: package_interface.Named("Float", "", "gleam", []),
+                  ),
+                ],
+              ),
+              TypeConstructor(
+                documentation: Some("A rectangle with width and height."),
+                name: "Rectangle",
+                parameters: [
+                  Parameter(
+                    label: Some("width"),
+                    type_: package_interface.Named("Float", "", "gleam", []),
+                  ),
+                  Parameter(
+                    label: Some("height"),
+                    type_: package_interface.Named("Float", "", "gleam", []),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ]),
+    )
+
+  let result = dts.emit_module(module, "test", "test_module")
+  // Constructor-level docs
+  result.content
+  |> string.contains("/** A circle with a radius. */\nexport interface Circle")
+  |> expect.to_be_true()
+  result.content
+  |> string.contains(
+    "/** A rectangle with width and height. */\nexport interface Rectangle",
+  )
+  |> expect.to_be_true()
+  // Type-level doc on the union
+  result.content
+  |> string.contains("/** A geometric shape. */\nexport type Shape")
+  |> expect.to_be_true()
+}
+
+pub fn emit_opaque_type_with_doc_test() {
+  let module =
+    Module(
+      ..empty_module(),
+      types: dict.from_list([
+        #(
+          "Secret",
+          TypeDefinition(
+            documentation: Some("An opaque secret value."),
+            deprecation: None,
+            parameters: 0,
+            constructors: [],
+          ),
+        ),
+      ]),
+    )
+
+  let result = dts.emit_module(module, "test", "test_module")
+  result.content
+  |> string.contains("/** An opaque secret value. */\nexport type Secret")
+  |> expect.to_be_true()
+}
+
+pub fn emit_no_doc_when_none_test() {
+  let module =
+    Module(
+      ..empty_module(),
+      functions: dict.from_list([
+        #(
+          "add",
+          Function(
+            documentation: None,
+            deprecation: None,
+            implementations: test_implementations(),
+            parameters: [],
+            return: package_interface.Named("Nil", "", "gleam", []),
+          ),
+        ),
+      ]),
+    )
+
+  let result = dts.emit_module(module, "test", "test_module")
+  // Should not contain any JSDoc
+  result.content
+  |> string.contains("/**")
+  |> expect.to_be_false()
+}


### PR DESCRIPTION
## Summary

- Improved `doc_comment` to use compact `/** text */` format for single-line docs and proper block format with ` * ` prefix for multi-line docs
- Added constructor-level JSDoc for ADT variant interfaces (e.g., each discriminated union member gets its own doc comment)
- Moved type-level docs to appear directly above the `export type` union declaration rather than above the first interface
- Handles empty/whitespace-only documentation gracefully

## Test plan

- [x] Added `emit_function_with_single_line_doc_test` — verifies compact single-line JSDoc
- [x] Added `emit_function_with_multi_line_doc_test` — verifies block JSDoc format
- [x] Added `emit_record_type_with_doc_test` — verifies doc before `export interface`
- [x] Added `emit_adt_type_with_docs_test` — verifies constructor-level and union-level docs
- [x] Added `emit_opaque_type_with_doc_test` — verifies doc before branded type
- [x] Added `emit_no_doc_when_none_test` — verifies no JSDoc when documentation is None
- [x] All 95 tests passing

Closes #3